### PR TITLE
Arghrad-style sun setup using light entity.

### DIFF
--- a/include/light/entities.hh
+++ b/include/light/entities.hh
@@ -75,6 +75,7 @@ public:
     lockable_vec_t light, atten, formula, spotangle, spotangle2, style, anglescale;
     lockable_vec_t dirtscale, dirtgain, dirt, deviance, samples, projfov, bouncescale;
     lockable_vec_t dirt_off_radius, dirt_on_radius;
+    lockable_vec_t sun; //mxd
     lockable_bool_t bleed;
     lockable_vec3_t origin, color, mangle, projangle;
     lockable_string_t project_texture;
@@ -111,6 +112,7 @@ public:
         bouncescale { "bouncescale", 1.0f },
         dirt_off_radius { "dirt_off_radius", 0.0f },
         dirt_on_radius { "dirt_on_radius", 0.0f },
+        sun { "sun", 0 }, //mxd
         bleed { "bleed", false },
         origin { "origin", 0, 0, 0 },
         color { "color", 255.0f, 255.0f, 255.0f, vec3_transformer_t::NORMALIZE_COLOR_TO_255 },
@@ -130,6 +132,7 @@ public:
             &light, &atten, &formula, &spotangle, &spotangle2, &style, &bleed, &anglescale,
             &dirtscale, &dirtgain, &dirt, &deviance, &samples, &projfov, &bouncescale,
             &dirt_off_radius, &dirt_on_radius,
+            &sun, //mxd
             &origin, &color, &mangle, &projangle, &project_texture
         }};
     }

--- a/light/entities.cc
+++ b/light/entities.cc
@@ -386,7 +386,7 @@ Dirt_ResolveFlag(const globalconfig_t &cfg, int dirtInt)
  * =============
  */
 static void
-AddSun(const globalconfig_t &cfg, vec3_t sunvec, vec_t light, const vec3_t color, int dirtInt)
+AddSun(const globalconfig_t &cfg, vec3_t sunvec, vec_t light, const vec3_t color, int dirtInt, float sun_anglescale)
 {
     if (light == 0.0f)
         return;
@@ -397,7 +397,7 @@ AddSun(const globalconfig_t &cfg, vec3_t sunvec, vec_t light, const vec3_t color
     VectorScale(sun.sunvec, -16384, sun.sunvec);
     sun.sunlight = light;
     VectorCopy(color, sun.sunlight_color);
-    sun.anglescale = cfg.global_anglescale.floatValue();
+	sun.anglescale = sun_anglescale;
     sun.dirt = Dirt_ResolveFlag(cfg, dirtInt);
 
     // add to list
@@ -422,17 +422,13 @@ AddSun(const globalconfig_t &cfg, vec3_t sunvec, vec_t light, const vec3_t color
  * =============
  */
 static void
-SetupSun(const globalconfig_t &cfg, vec_t light, const vec3_t color, const vec3_t sunvec_in)
+SetupSun(const globalconfig_t &cfg, vec_t light, const vec3_t color, const vec3_t sunvec_in, const float sun_anglescale, const float sun_deviance, const int sunlight_dirt)
 {
     vec3_t sunvec;
     int i;
-    int sun_num_samples = sunsamples;
-
-    if (cfg.sun_deviance.floatValue() == 0) {
-        sun_num_samples = 1;
-    } else {
-        logprint("using _sunlight_penumbra of %f degrees from worldspawn.\n", cfg.sun_deviance.floatValue());
-    }
+    int sun_num_samples = (sun_deviance == 0 ? 1 : sunsamples); //mxd
+    float sun_deviance_rad = DEG2RAD(sun_deviance); //mxd
+    float sun_deviance_sq = sun_deviance * sun_deviance; //mxd
 
     VectorCopy(sunvec_in, sunvec);
     VectorNormalize(sunvec);
@@ -460,10 +456,10 @@ SetupSun(const globalconfig_t &cfg, vec_t light, const vec3_t color, const vec3_
             /* jitter the angles (loop to keep random sample within sun->deviance steridians) */
             do
             {
-                da = ( Random() * 2.0f - 1.0f ) * DEG2RAD(cfg.sun_deviance.floatValue());
-                de = ( Random() * 2.0f - 1.0f ) * DEG2RAD(cfg.sun_deviance.floatValue());
+                da = ( Random() * 2.0f - 1.0f ) * sun_deviance_rad;
+                de = ( Random() * 2.0f - 1.0f ) * sun_deviance_rad;
             }
-            while ( ( da * da + de * de ) > ( cfg.sun_deviance.floatValue() * cfg.sun_deviance.floatValue() ) );
+            while ( ( da * da + de * de ) > sun_deviance_sq );
             angle += da;
             elevation += de;
 
@@ -475,18 +471,83 @@ SetupSun(const globalconfig_t &cfg, vec_t light, const vec3_t color, const vec3_
 
         //printf( "sun %d is using vector %f %f %f\n", i, direction[0], direction[1], direction[2]);
 
-        AddSun(cfg, direction, light, color, cfg.sunlight_dirt.intValue());
+        AddSun(cfg, direction, light, color, sunlight_dirt, sun_anglescale);
     }
 }
 
 static void
 SetupSuns(const globalconfig_t &cfg)
 {
-    SetupSun(cfg, cfg.sunlight.floatValue(), *cfg.sunlight_color.vec3Value(), *cfg.sunvec.vec3Value());
+	//mxd. Arghrad-style sun setup
+	bool sun_deviance_set_from_light;
+	float sunlight = cfg.sunlight.floatValue();
+	float sun_deviance = cfg.sun_deviance.floatValue();
+	float sun_anglescale = cfg.global_anglescale.floatValue();
+	int sunlight_dirt = cfg.sunlight_dirt.intValue();
+
+	vec3_t sunlight_color, sunvec;
+	VectorCopy(*cfg.sunlight_color.vec3Value(), sunlight_color);
+	VectorCopy(*cfg.sunvec.vec3Value(), sunvec);
+
+	for (light_t &entity : all_lights) {
+		if (entity.sun.intValue() == 1 && entity.light.intValue() > 0) {
+			// Set sun light
+			if (!cfg.sunlight.isLocked())
+				sunlight = entity.light.intValue();
+
+			// Set sun anglescale
+			if (!cfg.global_anglescale.isLocked() && entity.anglescale.floatValue() > 0)
+				sun_anglescale = entity.anglescale.floatValue();
+
+			// Set sun color
+			if (!cfg.sunlight_color.isLocked() && VectorLengthSq(*entity.color.vec3Value()) > 0)
+				VectorCopy(*entity.color.vec3Value(), sunlight_color);
+
+			// Set sun dirt
+			if (!cfg.sunlight_dirt.isLocked() && entity.dirt.intValue())
+				sunlight_dirt = entity.dirt.intValue();
+
+			// Set deviance
+			if (!cfg.sun_deviance.isLocked() && entity.deviance.floatValue()) {
+				sun_deviance = entity.deviance.floatValue();
+				
+				logprint("using _sunlight_penumbra of %f degrees from light.\n", sun_deviance);
+				sun_deviance_set_from_light = true;
+			}
+
+			// Set sun vector
+			if(!cfg.sunvec.isLocked()) {
+				if (entity.targetent) {
+					vec3_t sun_t;
+					EntDict_VectorForKey(*entity.targetent, "origin", sun_t);
+					VectorSubtract(sun_t, *entity.origin.vec3Value(), sunvec);
+				} else if (VectorLengthSq(*entity.mangle.vec3Value()) > 0) {
+					VectorCopy(*entity.mangle.vec3Value(), sunvec);
+				} else if (!sunvec) { // Use { 0, 0, 0 } as sun target...
+					logprint("WARNING: sun missing target, { 0 0 0 } used.\n");
+					VectorCopy(*entity.origin.vec3Value(), sunvec);
+				}
+			}
+
+			// Disable the light itself...
+			entity.light.setFloatValue(0.0f);
+
+			// One sun will suffice...
+			break;
+		}
+	}
+
+	if(!sun_deviance_set_from_light && cfg.sun_deviance.floatValue() != 0)
+		logprint("using _sunlight_penumbra of %f degrees from worldspawn.\n", cfg.sun_deviance.floatValue());
+
+	const vec3_t sc = { sunlight_color[0], sunlight_color[1], sunlight_color[2] };
+	const vec3_t sv = { sunvec[0], sunvec[1], sunvec[2] };
+
+	SetupSun(cfg, sunlight, sc, sv, sun_anglescale, sun_deviance, sunlight_dirt);
     
     if (cfg.sun2.floatValue() != 0) {
         logprint("creating sun2\n");
-        SetupSun(cfg, cfg.sun2.floatValue(), *cfg.sun2_color.vec3Value(), *cfg.sun2vec.vec3Value());
+        SetupSun(cfg, cfg.sun2.floatValue(), *cfg.sun2_color.vec3Value(), *cfg.sun2vec.vec3Value(), cfg.global_anglescale.floatValue(), cfg.sun_deviance.floatValue(), cfg.sunlight_dirt.intValue());
     }
 }
 
@@ -552,14 +613,14 @@ SetupSkyDome(const globalconfig_t &cfg)
 
                         /* insert top hemisphere light */
                         if (sunlight2value > 0) {
-                            AddSun(cfg, direction, sunlight2value, *cfg.sunlight2_color.vec3Value(), cfg.sunlight2_dirt.intValue());
+                            AddSun(cfg, direction, sunlight2value, *cfg.sunlight2_color.vec3Value(), cfg.sunlight2_dirt.intValue(), cfg.global_anglescale.floatValue());
                         }
 
                         direction[ 2 ] = -direction[ 2 ];
                     
                         /* insert bottom hemisphere light */
                         if (sunlight3value > 0) {
-                            AddSun(cfg, direction, sunlight3value, *cfg.sunlight3_color.vec3Value(), cfg.sunlight2_dirt.intValue());
+                            AddSun(cfg, direction, sunlight3value, *cfg.sunlight3_color.vec3Value(), cfg.sunlight2_dirt.intValue(), cfg.global_anglescale.floatValue());
                         }
                     
                         /* move */
@@ -575,13 +636,13 @@ SetupSkyDome(const globalconfig_t &cfg)
         VectorSet( direction, 0.0f, 0.0f, -1.0f );
 
         if (sunlight2value > 0) {
-            AddSun(cfg, direction, sunlight2value, *cfg.sunlight2_color.vec3Value(), cfg.sunlight2_dirt.intValue());
+            AddSun(cfg, direction, sunlight2value, *cfg.sunlight2_color.vec3Value(), cfg.sunlight2_dirt.intValue(), cfg.global_anglescale.floatValue());
         }
     
         VectorSet( direction, 0.0f, 0.0f, 1.0f );
     
         if (sunlight3value > 0) {
-            AddSun(cfg, direction, sunlight3value, *cfg.sunlight3_color.vec3Value(), cfg.sunlight2_dirt.intValue());
+            AddSun(cfg, direction, sunlight3value, *cfg.sunlight3_color.vec3Value(), cfg.sunlight2_dirt.intValue(), cfg.global_anglescale.floatValue());
         }
 }
 


### PR DESCRIPTION
Allows to set most of sun properties using a light entity with "_sun" key set to 1.
If the light targets an info_null entity, direction towards that entity sets sun direction.
Light itself is disabled, so it can be placed anywhere in the map.

Following light properties override corresponding worldspawn properties:
light -> _sunlight;
mangle -> _sunlight_mangle;
deviance -> _sunlight_penumbra;
_color ->	_sunlight_color;
_dirt -> _sunlight_dirt;
_anglescale -> _anglescale.

